### PR TITLE
Fixes #55: Add Mac OS X application initialization to enable support …

### DIFF
--- a/GUI/App.hs
+++ b/GUI/App.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE CPP #-}
+
+-------------------------------------------------------------------------------
+-- | Module : GUI.App
+--
+-- Platform-specific application functionality
+-------------------------------------------------------------------------------
+
+module GUI.App (initApp) where
+
+-- Imports for GTK
+import qualified Graphics.UI.Gtk as Gtk
+
+-- Mac OS X-specific GTK imports
+#if defined(darwin_HOST_OS)
+import qualified Graphics.UI.Gtk.OSX as OSX
+#endif
+
+-------------------------------------------------------------------------------
+
+#if defined(darwin_HOST_OS)
+
+-- | Initialize application
+-- Perform Mac OS X-specific application initialization
+initApp :: IO ()
+initApp = do
+  app <- OSX.applicationNew
+  menuBar <- Gtk.menuBarNew
+  OSX.applicationSetMenuBar app menuBar
+  OSX.applicationReady app
+
+#else
+
+-- | Initialize application
+-- Perform application initialization for non-Mac OS X platforms
+initApp :: IO ()
+initApp = return ()
+
+#endif

--- a/GUI/Main.hs
+++ b/GUI/Main.hs
@@ -21,6 +21,7 @@ import Data.Maybe
 import Paths_threadscope
 
 -- Imports for ThreadScope
+import qualified GUI.App as App
 import qualified GUI.MainWindow as MainWindow
 import GUI.Types
 import Events.HECs hiding (Event)
@@ -444,6 +445,8 @@ eventLoop uienv@UIEnv{..} eventlogState = do
 runGUI :: Maybe (Either FilePath String) -> IO ()
 runGUI initialTrace = do
   Gtk.initGUI
+
+  App.initApp
 
   uiEnv <- constructUI
 

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -48,6 +48,9 @@ Executable threadscope
                      deepseq >= 1.1,
                      text,
                      time >= 1.1
+  if os(osx)
+    build-depends:   gtk-mac-integration
+
   Extensions:        RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
   Other-Modules:     Events.HECs,
                      Events.EventDuration,
@@ -56,6 +59,7 @@ Executable threadscope
                      Events.SparkStats,
                      Events.SparkTree,
                      Events.TestEvents,
+                     GUI.App,
                      GUI.Main,
                      GUI.MainWindow,
                      GUI.EventsView,


### PR DESCRIPTION
…for Cmd-Q etc.

* Adds GUI.App module containing platform-specific code
* Mac OS X-specific behaviour depends on gtk-mac-integration package
* GUI.App.initApp adds empty menu bar to application object to enable standard keyboard shortcuts
* On other platforms GUI.App.initApp does nothing