### PR TITLE
v0.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Revision history for threadscope
+
+## 2017-07-17 - v0.2.8
+
+* Add macOS support (#56)
+* Update ghc-events to 0.6.0 (#61)
+* CI builds for Linux/Windows/macOS (#64, #65)
+* Set upper version bounds for dependencies

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -45,7 +45,7 @@ source-repository head
 
 Executable threadscope
   Main-is:           Main.hs
-  Build-Depends:     base >= 4.0 && < 5,
+  Build-Depends:     base >= 4.6 && < 5,
                      gtk >= 0.12 && < 0.15,
                      cairo < 0.14,
                      glib < 0.14,

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -46,13 +46,19 @@ source-repository head
 Executable threadscope
   Main-is:           Main.hs
   Build-Depends:     base >= 4.0 && < 5,
-                     gtk >= 0.12, cairo, glib, pango,
-                     binary, array, mtl, filepath,
+                     gtk >= 0.12 && < 0.15,
+                     cairo < 0.14,
+                     glib < 0.14,
+                     pango < 0.14,
+                     binary < 0.10,
+                     array < 0.6,
+                     mtl < 2.3,
+                     filepath < 1.5,
                      ghc-events >= 0.5 && < 0.7,
                      containers >= 0.2 && < 0.6,
                      deepseq >= 1.1,
-                     text,
-                     time >= 1.1
+                     text < 1.3,
+                     time >= 1.1 && < 1.9
   if os(osx)
     build-depends:   gtk-mac-integration
 

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -1,5 +1,5 @@
 Name:                threadscope
-Version:             0.2.7
+Version:             0.2.8
 Category:            Development, Profiling, Trace
 Synopsis:            A graphical tool for profiling parallel Haskell programs.
 Description:         ThreadScope is a graphical viewer for thread profile


### PR DESCRIPTION
I've tighten some upper and lower version bounds to make the [matrix builder](https://matrix.hackage.haskell.org/package/threadscope) happy. It might still be possible to make threadscope compatible with GHC 7.4 but I don't think it's worth doing.