### PR TITLE
Embed data files into binary for easier deployment

### DIFF
--- a/GUI/App.hs
+++ b/GUI/App.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -------------------------------------------------------------------------------
 -- | Module : GUI.App
@@ -12,6 +13,7 @@ module GUI.App (initApp) where
 #if defined(darwin_HOST_OS)
 import qualified Graphics.UI.Gtk as Gtk
 import qualified Graphics.UI.Gtk.OSX as OSX
+import GUI.DataFiles (loadLogo)
 #endif
 
 -------------------------------------------------------------------------------
@@ -25,6 +27,8 @@ initApp = do
   app <- OSX.applicationNew
   menuBar <- Gtk.menuBarNew
   OSX.applicationSetMenuBar app menuBar
+  logo <- $loadLogo
+  OSX.applicationSetDockIconPixbuf app (Just logo)
   OSX.applicationReady app
 
 #else

--- a/GUI/DataFiles.hs
+++ b/GUI/DataFiles.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+module GUI.DataFiles
+  ( ui
+  , loadLogo
+  ) where
+import System.IO
+
+import Data.FileEmbed
+import Graphics.UI.Gtk (Pixbuf, pixbufNewFromFile)
+import Language.Haskell.TH
+import System.IO.Temp
+import qualified Data.ByteString as B
+import qualified Data.Text.Encoding as TE
+
+uiFile :: FilePath
+uiFile = "threadscope.ui"
+
+logoFile :: FilePath
+logoFile = "threadscope.png"
+
+-- | Textual representaion of the UI file
+ui :: Q Exp
+ui = [| TE.decodeUtf8 $(makeRelativeToProject uiFile >>= embedFile) |]
+
+renderLogo :: B.ByteString -> IO Pixbuf
+renderLogo bytes =
+  withSystemTempFile logoFile $ \path h -> do
+    B.hPut h bytes
+    hClose h
+    pixbufNewFromFile path
+
+-- | Load the logo file as a 'Pixbuf'.
+loadLogo :: Q Exp
+loadLogo = [| renderLogo $(makeRelativeToProject logoFile >>= embedFile) |]

--- a/GUI/Dialogs.hs
+++ b/GUI/Dialogs.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
 module GUI.Dialogs where
 
-import Paths_threadscope (getDataFileName, version)
+import GUI.DataFiles (loadLogo)
+import Paths_threadscope (version)
 
 import Graphics.UI.Gtk
 
@@ -13,8 +15,7 @@ import System.FilePath
 aboutDialog :: WindowClass window => window -> IO ()
 aboutDialog parent
  = do dialog <- aboutDialogNew
-      logoPath <- getDataFileName "threadscope.png"
-      logo <- pixbufNewFromFile logoPath
+      logo <- $loadLogo
       set dialog [
          aboutDialogName      := "ThreadScope",
          aboutDialogVersion   := showVersion version,

--- a/GUI/Main.hs
+++ b/GUI/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 module GUI.Main (runGUI) where
 
 -- Imports for GTK
@@ -16,13 +17,12 @@ import Control.Exception
 import Data.Array
 import Data.Maybe
 
-import Paths_threadscope
-
 -- Imports for ThreadScope
 import qualified GUI.App as App
 import qualified GUI.MainWindow as MainWindow
 import GUI.Types
 import Events.HECs hiding (Event)
+import GUI.DataFiles (ui)
 import GUI.Dialogs
 import Events.ReadEvents
 import GUI.EventsView
@@ -117,7 +117,7 @@ constructUI :: IO UIEnv
 constructUI = failOnGError $ do
 
   builder <- Gtk.builderNew
-  Gtk.builderAddFromFile builder =<< getDataFileName "threadscope.ui"
+  Gtk.builderAddFromString builder $ui
 
   eventQueue <- Chan.newChan
   let post = postEvent eventQueue

--- a/GUI/MainWindow.hs
+++ b/GUI/MainWindow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 module GUI.MainWindow (
     MainWindow,
     mainWindowNew,
@@ -10,12 +11,10 @@ module GUI.MainWindow (
 
   ) where
 
-import Paths_threadscope
-
--- Imports for GTK
 import Graphics.UI.Gtk as Gtk
 import qualified System.Glib.GObject as Glib
 
+import GUI.DataFiles (loadLogo)
 
 -------------------------------------------------------------------------------
 
@@ -146,8 +145,8 @@ mainWindowNew builder actions = do
 
   ------------------------------------------------------------------------
 
-  logoPath <- getDataFileName "threadscope.png"
-  windowSetIconFromFile mainWindow logoPath
+  logo <- $loadLogo
+  set mainWindow [ windowIcon := Just logo ]
 
   ------------------------------------------------------------------------
   -- Status bar functionality

--- a/README.md
+++ b/README.md
@@ -3,3 +3,67 @@
 [![Hackage-Deps](https://img.shields.io/hackage-deps/v/threadscope.svg)](http://packdeps.haskellers.com/feed?needle=threadscope)
 [![Build Status](https://travis-ci.org/haskell/ThreadScope.svg?branch=master)](https://travis-ci.org/haskell/ThreadScope)
 [![Build status](https://ci.appveyor.com/api/projects/status/y6kd8pyh2f3qok4f?svg=true)](https://ci.appveyor.com/project/Mikolaj/threadscope)
+
+## Installation
+
+### Linux
+
+GTK+2 is required to be installed. On Ubuntu-like systems:
+
+```sh
+sudo apt install libgtk2.0-dev
+```
+
+Then you can build threadscope using cabal:
+```sh
+cabal new-build
+```
+
+Or using stack:
+```sh
+stack setup
+stack install
+```
+
+### macOS
+
+GTK+ and gtk-mac-integration are required.
+
+```sh
+brew install gtk+ gtk-mac-integration
+```
+
+Then you can build threadscope using cabal:
+```sh
+cabal new-build --constraint="gtk +have-quartz-gtk"
+```
+
+Or using stack:
+```sh
+stack setup
+stack install --flag gtk:have-quartz-gtk
+```
+
+### Windows
+
+stack is the recommended tool to build threadscope on Windows.
+
+CAVEAT: Currently gtk2 needs to be installed twice: one for stack's MSYS2 environment and another for local MSYS2 environment.
+
+In command prompt:
+```sh
+stack setup
+stack exec -- pacman --needed -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel
+stack exec -- pacman -Syu
+stack exec -- pacman -Syuu
+stack exec -- pacman -S base-devel mingw-w64-x86_64-pkg-config mingw-w64-x86_64-toolchain mingw-w64-x86_64-gtk2
+stack install
+```
+
+Then in MSYS2 MINGW64 shell:
+```sh
+pacman -S $MINGW_PACKAGE_PREFIX-gtk2
+echo 'export PATH=$APPDATA/local/bin:$PATH' >> .profile
+source .profile
+threadscope
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,21 @@ platform: x64
 shallow_clone: true
 environment:
   global:
-    STACK_ROOT: "c:\\sr"
+    STACK_ROOT: c:\sr
 cache:
-- "c:\\sr -> appveyor.yml"
+- c:\sr -> appveyor.yml
+- c:\msys64\var\cache\pacman\pkg -> appveyor.yml
 install:
 - set HOME=.
-- set "PATH=C:\msys64\usr\bin;%PATH%"
+- set "PATH=c:\msys64\usr\bin;%PATH%"
 - curl -ostack.zip -LsS --insecure https://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
 - stack setup > nul
 - stack exec -- pacman --noconfirm --needed -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel
 - stack exec -- pacman --noconfirm -Syu
 - stack exec -- pacman --noconfirm -Syuu
-- stack exec -- pacman --noconfirm -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-gtk2
+- stack exec -- pacman --noconfirm -S base-devel mingw-w64-x86_64-pkg-config mingw-w64-x86_64-toolchain mingw-w64-x86_64-gtk2
+- stack exec -- pacman --noconfirm -Sc
 build_script:
 - stack --no-terminal build --only-dependencies
 test_script:

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -64,7 +64,7 @@ Executable threadscope
                      template-haskell < 2.13,
                      temporary >= 1.1 && < 1.3
   if os(osx)
-    build-depends:   gtk-mac-integration
+    build-depends:   gtk-mac-integration < 0.4
 
   Extensions:        RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
   Other-Modules:     Events.HECs,

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -58,7 +58,11 @@ Executable threadscope
                      containers >= 0.2 && < 0.6,
                      deepseq >= 1.1,
                      text < 1.3,
-                     time >= 1.1 && < 1.9
+                     time >= 1.1 && < 1.9,
+                     bytestring < 0.11,
+                     file-embed < 0.1,
+                     template-haskell < 2.13,
+                     temporary >= 1.1 && < 1.3
   if os(osx)
     build-depends:   gtk-mac-integration
 
@@ -74,6 +78,7 @@ Executable threadscope
                      GUI.Main,
                      GUI.MainWindow,
                      GUI.EventsView,
+                     GUI.DataFiles,
                      GUI.Dialogs,
                      GUI.SaveAs,
                      GUI.Timeline,


### PR DESCRIPTION
This PR embeds the two files
* threadscope.ui for the Glade UI builder
* threadscope.png which is the logo
 
into the threadscope binary using TH in order to make deployment simpler.

There are a few scenarios that will be made simpler with this change:

* We'll be able to build binaries on Travis/AppVeyor and have them upload the binaries to GitHub Releases without worrying about the data files.
* If you build threadscope with `cabal new-build` (at least from current master), these files aren't installed. So you'll get a runtime error failing to find the UI file. No runtime error after this change.

The possible downsides are:

* More dependencies and an extension.
    * TH is necessary. I don't think it's a problem though as I think it's unlikely to use threadscope on exotic platforms that have no TH support.
    *  `temporary` is optional because we can write the same function using only `base` but I don't think it's worth it.

Also I've added the logo as an Dock icon on macOS using the same TH function. This is optional and can be a separate PR if that's better.

I've confirmed this code on macOS and Linux.