### PR TITLE
travis: Use the cabal-install builds for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
     - $HOME/.cabal/packages
     - $HOME/.cabal/store
     - $HOME/Library/Caches/Homebrew
-    - $HOME/cabal
+    - $HOME/.ghc-install
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
@@ -44,30 +44,19 @@ matrix:
     - compiler: "ghc-8.2.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1,libgtk2.0-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc"
+    - compiler: "ghc-8.2.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
       os: osx
 
 before_install:
  - HC=${CC}
  - unset CC
- - PATH=$HOME/.cabal/bin:/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
+ - sh scripts/install-on-osx.sh $HC
+ - PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$HOME/.ghc-install/bin:$PATH
  - PKGNAME='threadscope'
  - |
   if [ `uname` = "Darwin" ]; then
     brew install ghc gtk+ gtk-mac-integration
-    pushd $HOME
-    if [ -d cabal/.git ]; then
-      cd cabal
-      git fetch origin
-    else
-      git clone https://github.com/haskell/cabal.git
-    fi
-    cd $HOME/cabal/cabal-install
-    git checkout 3751ec6
-    NO_DOCUMENTATION=1 EXTRA_CONFIGURE_OPTS="" ./bootstrap.sh -j --sandbox
-    mkdir -p $HOME/.cabal/bin
-    cp -v .cabal-sandbox/bin/cabal $HOME/.cabal/bin/cabal
-    popd
   fi
 
 install:

--- a/scripts/install-on-osx.sh
+++ b/scripts/install-on-osx.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+HC=$1
+
+set -ex
+
+CABALPKG="cabal-c92b4ea7ce036fae6ebf3c2965d6ecc0ef252775-20170725-123913.xz"
+CABALCHECKSUM="2aa74ff75ee97745eb562360ed4e8f95f3eba4ce40c8621b6b23e29633f6ed3a"
+
+GHCPKG="ghc-8.2.1-x86_64-apple-darwin.tar.xz"
+GHCURL="https://downloads.haskell.org/~ghc/8.2.1/$GHCPKG"
+GHCCHECKSUM="900c802025fb630060dbd30f9738e5d107a4ca5a50d5c1262cd3e69fe4467188"
+
+if [ $(uname) != "Darwin" ]; then
+    exit 0
+fi
+
+if [ "x$HC" != "xghc-8.2.1" ]; then
+    echo "Only GHC-8.2.1 is supported at the moment"
+    exit 1
+fi
+
+ROOTDIR=$(pwd)
+BUILDDIR=$(mktemp -d /tmp/build-cabal-nightly.XXXXXX)
+
+travis_retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*)
+}
+
+if [ ! -f $HOME/.ghc-install/bin/ghc-8.2.1 ]; then
+    cd $BUILDDIR
+
+    travis_retry curl -OL $GHCURL
+    # Two spaces seems to be important
+    echo "$GHCCHECKSUM  ./$GHCPKG" | shasum -c -a 256
+
+    tar -xJf $GHCPKG
+    cd ghc-*
+    ./configure --prefix=$HOME/.ghc-install
+    make install
+fi
+
+if [ ! -f $HOME/.ghc-install/bin/cabal ]; then
+    cd $BUILDDIR
+
+    travis_retry curl -OL https://haskell.futurice.com/files/$CABALPKG
+    echo "$CABALCHECKSUM  ./$CABALPKG" | shasum -c -a 256
+
+    # gunzip knows how to handle .xz
+    gunzip -c $CABALPKG > $HOME/.ghc-install/bin/cabal
+    mkdir -p $HOME/.ghc-install/bin
+    chmod a+x $HOME/.ghc-install/bin/cabal
+fi


### PR DESCRIPTION
This PR switches the Travis build on macOS to use https://haskell.futurice.com/.