### PR TITLE
Render GCEnd period in light orange

### DIFF
--- a/GUI/KeyView.hs
+++ b/GUI/KeyView.hs
@@ -63,6 +63,8 @@ keyData =
      "Indicates a period of time spent running Haskell code (not GC, not blocked/idle)")
   , ("GC",              KDuration, gcColour,
      "Indicates a period of time spent by the RTS performing garbage collection (GC)")
+  , ("GC waiting",      KDuration, gcWaitColour,
+     "Indicates a period of time spent by the RTS waiting to initiate or finish garbage collection (GC)")
   , ("create thread",   KEvent, createThreadColour,
      "Indicates a new Haskell thread has been created")
   , ("seq GC req",      KEvent, seqGCReqColour,

--- a/GUI/ViewerColours.hs
+++ b/GUI/ViewerColours.hs
@@ -18,11 +18,14 @@ runningColour = darkGreen
 gcColour :: Color
 gcColour = orange
 
+gcWaitColour :: Color
+gcWaitColour = lightOrange
+
 gcStartColour, gcWorkColour, gcIdleColour, gcEndColour :: Color
-gcStartColour = orange
+gcStartColour = lightOrange
 gcWorkColour  = orange
-gcIdleColour  = white
-gcEndColour   = orange
+gcIdleColour  = lightOrange
+gcEndColour   = lightOrange
 
 createThreadColour :: Color
 createThreadColour = lightBlue
@@ -108,6 +111,9 @@ darkRed = Color 0xcc00 0x0000 0x0000
 
 orange :: Color
 orange = Color 0xE000 0x7000 0x0000 -- orange
+
+lightOrange :: Color
+lightOrange = Color 0xE000 0xD000 0xB000 -- orange
 
 profileBackground :: Color
 profileBackground = Color 0xFFFF 0xFFFF 0xFFFF


### PR DESCRIPTION
Fixes #69, where the GCEnd duration of a HEC is mis-leadingly rendered
as orange, suggesting that the HEC is busy whereas it is likely simply
waiting for other HECs to finish their GCs.