### PR TITLE
Use appropriate calling convention on Windows depending on the host architecture

### DIFF
--- a/GUI/GtkExtras.hs
+++ b/GUI/GtkExtras.hs
@@ -20,6 +20,8 @@ import System.Glib.GError
 import Control.Monad
 #endif
 
+#include "windows_cconv.h"
+
 waitGUI :: IO ()
 waitGUI = do
   resultVar <- newEmptyMVar
@@ -94,7 +96,7 @@ launchProgramForURI uri = do
             1       -- SW_SHOWNORMAL
     return True
 
-foreign import ccall unsafe "shlobj.h ShellExecuteA"
+foreign import WINDOWS_CCONV unsafe "shlobj.h ShellExecuteA"
     c_ShellExecuteA :: Ptr ()  -- HWND hwnd
                     -> CString -- LPCTSTR lpOperation
                     -> CString -- LPCTSTR lpFile

--- a/include/windows_cconv.h
+++ b/include/windows_cconv.h
@@ -1,0 +1,12 @@
+#ifndef __WINDOWS_CCONV_H
+#define __WINDOWS_CCONV_H
+
+#if defined(i386_HOST_ARCH)
+# define WINDOWS_CCONV stdcall
+#elif defined(x86_64_HOST_ARCH)
+# define WINDOWS_CCONV ccall
+#else
+# error Unknown mingw32 arch
+#endif
+
+#endif

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -33,6 +33,7 @@ Bug-reports:         https://github.com/haskell/ThreadScope/issues
 Build-Type:          Simple
 Cabal-version:       >= 1.6
 Data-files:          threadscope.ui, threadscope.png
+Extra-source-files:  include/windows_cconv.h
 Tested-with:         GHC == 7.6.3,
                      GHC == 7.8.3,
                      GHC == 7.10.2,
@@ -62,6 +63,7 @@ Executable threadscope
   if os(osx)
     build-depends:   gtk-mac-integration
 
+  include-dirs:      include
   Extensions:        RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
   Other-Modules:     Events.HECs,
                      Events.EventDuration,


### PR DESCRIPTION
@Mistuke pointed out that we can't use the ccall calling convention on Windows x86.

https://github.com/haskell/ThreadScope/commit/299546b7aef4155849437d327d34059589a82643#commitcomment-23352756

Unfortunately we don't have AppVeyor build on x86 (yet) so I'm not 100% sure this works but I guess it does.