### PR TITLE
Upload binaries to GitHub Releases from Travis/AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,4 +103,18 @@ script:
  # build & run tests
  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
 
+before_deploy:
+- cp $(find dist-newstyle/ -type f -name threadscope -exec test -x {} \; -print) threadscope.$TRAVIS_OS_NAME
+- gzip -f threadscope.$TRAVIS_OS_NAME
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "CLdDbxzqQRTU6wMRqyMutoprbgr8o6fQfIYZc7DBkbRi1r6bOpJl/2Bmob6FYC1XhMsdeBhZfLy0a0MqcU4LNbToLtR8yKN+SvmfEUQn3novk69vfI5KipFqLLeduN4oHgGXSdjIdck3nF/ze8kB2ottJUNdp8J3UxAgMwS9AF8="
+  file: threadscope.$TRAVIS_OS_NAME.gz
+  skip_cleanup: true
+  on:
+    repo: haskell/ThreadScope
+    tags: true
+    condition: "$HC = ghc-8.2.1"
 # EOF

--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 [![Hackage](https://img.shields.io/hackage/v/threadscope.svg)](https://hackage.haskell.org/package/threadscope)
 [![Hackage-Deps](https://img.shields.io/hackage-deps/v/threadscope.svg)](http://packdeps.haskellers.com/feed?needle=threadscope)
 [![Build Status](https://travis-ci.org/haskell/ThreadScope.svg?branch=master)](https://travis-ci.org/haskell/ThreadScope)
-[![Build status](https://ci.appveyor.com/api/projects/status/y6kd8pyh2f3qok4f?svg=true)](https://ci.appveyor.com/project/Mikolaj/threadscope)
+[![Build status](https://ci.appveyor.com/api/projects/status/tiwkb7k6p38dde03/branch/master?svg=true)](https://ci.appveyor.com/project/maoe/threadscope-44t6e/branch/master)
 
-## Installation
+## Using pre-built binaries
+
+Currently [pre-built binaries](https://github.com/haskell/ThreadScope/releases) for the following platforms are provided:
+
+* Ubuntu Trusty (64-bit)
+* OS X
+* Windows (x64)
+
+GTK+2 needs to be installed for those binaries to work. On OS X, `gtk-mac-integration` also needs to be installed.
+
+## Building from source
 
 ### Linux
 
@@ -25,7 +35,7 @@ stack setup
 stack install
 ```
 
-### macOS
+### OS X
 
 GTK+ and gtk-mac-integration are required.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,3 +23,16 @@ test_script:
 - stack --no-terminal build --ghc-options -Werror
 - stack sdist
 version: '{build}'
+after_test:
+- ps: cp "$(./stack.exe path --local-install-root)/bin/threadscope.exe" threadscope.exe
+- 7z a threadscope.windows.%PLATFORM%.zip threadscope.exe
+artifacts:
+- path: threadscope.windows.%PLATFORM%.zip
+deploy:
+- provider: GitHub
+  auth_token:
+    secure: IbU7Tokqkdq4bI5PT+HvzG0hO4O8t2Lxq3GamSuAzWsQWt4vZahOGL9StxIXIe94
+  artifact: threadscope.windows.$(platform).zip
+  release: $(appveyor_repo_tag_name)
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
This enables binary releases on GitHub Releases. Travis and AppVeyor upload binaries to GitHub Releases on every tag.

It's marked as WIP because I need @Mikolaj's help to complete the setup. I'll describe the instructions to set up Travis and AppVeyor for the binary release.

As for Travis, 

1. Generate a new [personal access token](https://github.com/settings/tokens) with `public_repo` scope. Note that the secret token is necessary at a later step.
1. Install [Travis CI client](https://github.com/travis-ci/travis.rb)
1. `travis encrypt -r haskell/ThreadScope $SECRET_TOKEN` encrypts the token.
1. Update `deploy.api_key.secure` in .travis.yml with the encrypted token.

And for AppVeyor,

1. Add [new deployment](https://ci.appveyor.com/project/Mikolaj/threadscope/settings/deployment). Only the GitHub authentication token and artifact(s) to deploy are necessary. The former is the secret token and the latter is `threadscope.windows.$(platform).zip`.
1. [Export project config to YAML](https://ci.appveyor.com/project/Mikolaj/threadscope/settings/yaml)
1. Update `deploy.auth_token.secure` in appveyor.yml with the exported one.

Once above is done, we can push a test tag to check the setup.

@Mikolaj Could you please try above?
