### PR TITLE
Do not include windows_cconv.h on non mingw32 systems

### DIFF
--- a/GUI/GtkExtras.hs
+++ b/GUI/GtkExtras.hs
@@ -15,12 +15,12 @@ import Foreign
 import Foreign.C
 import Control.Concurrent.MVar
 
-#if !(mingw32_HOST_OS || mingw32_TARGET_OS)
+#if mingw32_HOST_OS || mingw32_TARGET_OS
+#include "windows_cconv.h"
+#else
 import System.Glib.GError
 import Control.Monad
 #endif
-
-#include "windows_cconv.h"
 
 waitGUI :: IO ()
 waitGUI = do


### PR DESCRIPTION
Do not include windows_cconv.h on non windows systems, or else build
fails with `#error Unknown mingw32 arch` on architectures other than
i386 or x86_64.

This causes ThreadScope to fail to build on architectures other than i386 or x86_64.
As an example, see the build logs on [arm64](https://buildd.debian.org/status/fetch.php?pkg=threadscope&arch=arm64&ver=0.2.9-1&stamp=1505020359&raw=0).