### PR TITLE
Relax upper version bound for ghc-events and work around build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-7.6.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3,libgtk2.0-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.3,libgtk2.0-dev], sources: [hvr-ghc]}}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 - curl -ostack.zip -LsS --insecure https://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
 - stack setup > nul
-- stack exec -- pacman --noconfirm --needed -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel
+- stack exec -- pacman --noconfirm --needed --ask 20 -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel
 - stack exec -- pacman --noconfirm -Syu
 - stack exec -- pacman --noconfirm -Syuu
 - stack exec -- pacman --noconfirm -S base-devel mingw-w64-x86_64-pkg-config mingw-w64-x86_64-toolchain mingw-w64-x86_64-gtk2

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -56,7 +56,7 @@ Executable threadscope
                      array < 0.6,
                      mtl < 2.3,
                      filepath < 1.5,
-                     ghc-events >= 0.5 && < 0.7,
+                     ghc-events >= 0.5 && < 0.8,
                      containers >= 0.2 && < 0.6,
                      deepseq >= 1.1,
                      text < 1.3,

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -35,8 +35,7 @@ Cabal-version:       >= 1.6
 Data-files:          threadscope.ui, threadscope.png
 Extra-source-files:  include/windows_cconv.h
                      README.md
-Tested-with:         GHC == 7.6.3,
-                     GHC == 7.8.3,
+Tested-with:         GHC == 7.8.3,
                      GHC == 7.10.2,
                      GHC == 8.0.2,
                      GHC == 8.2.1


### PR DESCRIPTION
ghc-events-0.7.0 was released months ago. This relaxes the upper version bound and also works around a couple of build issues.