### PR TITLE
Modernise Appveyor CI script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,38 +1,52 @@
-platform: x64
+version: "{build}"
 shallow_clone: true
+clone_folder: "c:/WORK"
+
+platform: x64
+
 environment:
   global:
-    STACK_ROOT: c:\sr
+    APPVEYOR_SAVE_CACHE_ON_ERROR: true
+    CABOPTS: "--store-dir=c:/SR --http-transport=plain-http"
+#   C_INCLUDE_PATH: "c:/msys64/mingw64/include"
+#   LIBRARY_PATH: "c:/msys64/mingw64/lib;c:/msys64/mingw64/bin"
+  matrix:
+    - GHCVER: "8.0.2"
+    - GHCVER: "8.2.2"
+#   - GHCVER: "7.10.3.2"
+
 cache:
-- c:\sr -> appveyor.yml
-- c:\msys64\var\cache\pacman\pkg -> appveyor.yml
+ - "c:/SR"
+#- c:\msys64\var\cache\pacman\pkg -> appveyor.yml
+
 install:
-- set HOME=.
-- set "PATH=c:\msys64\usr\bin;%PATH%"
-- curl -ostack.zip -LsS --insecure https://www.stackage.org/stack/windows-x86_64
-- 7z x stack.zip stack.exe
-- stack setup > nul
-- stack exec -- pacman --noconfirm --needed --ask 20 -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel
-- stack exec -- pacman --noconfirm -Syu
-- stack exec -- pacman --noconfirm -Syuu
-- stack exec -- pacman --noconfirm -S base-devel mingw-w64-x86_64-pkg-config mingw-w64-x86_64-toolchain mingw-w64-x86_64-gtk2
-- stack exec -- pacman --noconfirm -Sc
+ - "choco install -y ghc --version %GHCVER%"
+ - "refreshenv"
+ - "set PATH=C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin;%PATH%"
+ - "pacman --noconfirm -Sy mingw-w64-x86_64-gtk2"
+ - "cabal --version"
+ - "ghc --version"
+ - "cabal %CABOPTS% update -vverbose+nowrap"
+
 build_script:
-- stack --no-terminal build --only-dependencies
+ - "cabal %CABOPTS% new-build -vnormal+nowrap --dry all"
+ - ps: "Push-AppveyorArtifact dist-newstyle\\cache\\plan.json"
+ - "cabal %CABOPTS% new-build -j -vnormal+nowrap all --dep"
+
 test_script:
-- stack --no-terminal build --ghc-options -Werror
-- stack sdist
-version: '{build}'
+ - "cabal %CABOPTS% new-build -j1 -vnormal+nowrap all"
+#- "cabal %CABOPTS% new-test -j1 -vnormal+nowrap all"
+
 after_test:
-- ps: cp "$(./stack.exe path --local-install-root)/bin/threadscope.exe" threadscope.exe
-- 7z a threadscope.windows.%PLATFORM%.zip threadscope.exe
-artifacts:
-- path: threadscope.windows.%PLATFORM%.zip
+ - bash -c "cp -v $(find -name threadscope.exe) ./threadscope.exe"
+ - 7z a threadscope.windows.%PLATFORM%.ghc-%GHCVER%.zip threadscope.exe
+ - ps: "Push-AppveyorArtifact threadscope.windows.$($env:PLATFORM).ghc-$($env:GHCVER).zip"
+
 deploy:
-- provider: GitHub
-  auth_token:
-    secure: IbU7Tokqkdq4bI5PT+HvzG0hO4O8t2Lxq3GamSuAzWsQWt4vZahOGL9StxIXIe94
-  artifact: threadscope.windows.$(platform).zip
-  release: $(appveyor_repo_tag_name)
-  on:
-    appveyor_repo_tag: true
+ - provider: GitHub
+   auth_token:
+     secure: IbU7Tokqkdq4bI5PT+HvzG0hO4O8t2Lxq3GamSuAzWsQWt4vZahOGL9StxIXIe94
+   artifact: threadscope.windows.$(platform).ghc-$(GHCVER).zip
+   release: $(appveyor_repo_tag_name)
+   on:
+     appveyor_repo_tag: true

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+-- see http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html for more information
+
+packages: .


### PR DESCRIPTION
This allows to build artifacts for more than one GHC version and
uses a more state-of-the-art way of building Threadscope.