### PR TITLE
Set correct application title in GNOME shell

### DIFF
--- a/GUI/App.hs
+++ b/GUI/App.hs
@@ -7,16 +7,24 @@
 -- Platform-specific application functionality
 -------------------------------------------------------------------------------
 
-module GUI.App (initApp) where
+module GUI.App (appTitle, initApp) where
 
 -- Mac OS X-specific GTK imports
 #if defined(darwin_HOST_OS)
+import Control.Monad (void)
 import qualified Graphics.UI.Gtk as Gtk
 import qualified Graphics.UI.Gtk.OSX as OSX
 import GUI.DataFiles (loadLogo)
+#else
+import Control.Monad (void)
+import qualified Graphics.UI.Gtk as Gtk
+import System.Glib.Utils (setProgramName)
 #endif
 
 -------------------------------------------------------------------------------
+
+appTitle :: String
+appTitle = "ThreadScope"
 
 #if defined(darwin_HOST_OS)
 
@@ -24,6 +32,7 @@ import GUI.DataFiles (loadLogo)
 -- Perform Mac OS X-specific application initialization
 initApp :: IO ()
 initApp = do
+  void Gtk.initGUI
   app <- OSX.applicationNew
   menuBar <- Gtk.menuBarNew
   OSX.applicationSetMenuBar app menuBar
@@ -36,6 +45,8 @@ initApp = do
 -- | Initialize application
 -- Perform application initialization for non-Mac OS X platforms
 initApp :: IO ()
-initApp = return ()
+initApp = do
+  setProgramName appTitle
+  void Gtk.initGUI
 
 #endif

--- a/GUI/Dialogs.hs
+++ b/GUI/Dialogs.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module GUI.Dialogs where
 
+import GUI.App (appTitle)
 import GUI.DataFiles (loadLogo)
 import Paths_threadscope (version)
 
@@ -17,7 +18,7 @@ aboutDialog parent
  = do dialog <- aboutDialogNew
       logo <- $loadLogo
       set dialog [
-         aboutDialogName      := "ThreadScope",
+         aboutDialogName      := appTitle,
          aboutDialogVersion   := showVersion version,
          aboutDialogCopyright := "Released under the GHC license as part of the Glasgow Haskell Compiler.",
          aboutDialogComments  := "A GHC eventlog profile viewer",

--- a/GUI/Main.hs
+++ b/GUI/Main.hs
@@ -442,8 +442,6 @@ eventLoop uienv@UIEnv{..} eventlogState = do
 
 runGUI :: Maybe (Either FilePath String) -> IO ()
 runGUI initialTrace = do
-  Gtk.initGUI
-
   App.initApp
 
   uiEnv <- constructUI

--- a/GUI/MainWindow.hs
+++ b/GUI/MainWindow.hs
@@ -14,6 +14,7 @@ module GUI.MainWindow (
 import Graphics.UI.Gtk as Gtk
 import qualified System.Glib.GObject as Glib
 
+import GUI.App (appTitle)
 import GUI.DataFiles (loadLogo)
 
 -------------------------------------------------------------------------------
@@ -69,11 +70,11 @@ data MainWindowActions = MainWindowActions {
 setFileLoaded :: MainWindow -> Maybe FilePath -> IO ()
 setFileLoaded mainWin Nothing =
   set (mainWindow mainWin) [
-      windowTitle := "ThreadScope"
+      windowTitle := appTitle
     ]
 setFileLoaded mainWin (Just file) =
   set (mainWindow mainWin) [
-      windowTitle := file ++ " - ThreadScope"
+      windowTitle := file ++ " - " ++ appTitle
     ]
 
 setStatusMessage :: MainWindow -> String -> IO ()


### PR DESCRIPTION
Prior to this change, the application will show up as "Threadscope" (lower-case "s") instead of "ThreadScope" in GNOME shell (e.g. Ubuntu). This change makes the capitalization of the application name consistent in the UI. I have not, yet, figured out how to get the application name to show up consistently under macOS.
