### PR TITLE
Bump package bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
 script:
   # test that source-distributions can be generated
   - (cd "." && cabal sdist)
-  - mv "."/dist-newstyle/threadscope-*.tar.gz ${DISTDIR}/
+  - mv "."/dist-newstyle/sdist/threadscope-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: threadscope-*/*.cabal\\n' > cabal.project"

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
 script:
   # test that source-distributions can be generated
   - (cd "." && cabal sdist)
-  - mv "."/dist/threadscope-*.tar.gz ${DISTDIR}/
+  - mv "."/dist-newstyle/threadscope-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: threadscope-*/*.cabal\\n' > cabal.project"

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -51,7 +51,7 @@ Executable threadscope
                      cairo < 0.14,
                      glib < 0.14,
                      pango < 0.14,
-                     binary < 0.10,
+                     binary < 0.11,
                      array < 0.6,
                      mtl < 2.3,
                      filepath < 1.5,

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -47,7 +47,7 @@ source-repository head
 Executable threadscope
   Main-is:           Main.hs
   Build-Depends:     base >= 4.6 && < 5,
-                     gtk >= 0.12 && < 0.15,
+                     gtk >= 0.12 && < 0.16,
                      cairo < 0.14,
                      glib < 0.14,
                      pango < 0.14,
@@ -62,7 +62,7 @@ Executable threadscope
                      time >= 1.1 && < 1.10,
                      bytestring < 0.11,
                      file-embed < 0.1,
-                     template-haskell < 2.14,
+                     template-haskell < 2.15,
                      temporary >= 1.1 && < 1.4
   if os(osx)
     build-depends:   gtk-mac-integration < 0.4


### PR DESCRIPTION
This allows `threadscope` to be built with GHC 8.6.4