### PR TITLE
Relax upper version bound for ghc-events

### DIFF
--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -55,7 +55,7 @@ Executable threadscope
                      array < 0.6,
                      mtl < 2.3,
                      filepath < 1.5,
-                     ghc-events >= 0.5 && < 0.12,
+                     ghc-events >= 0.5 && < 0.13,
                      containers >= 0.2 && < 0.7,
                      deepseq >= 1.1,
                      text < 1.3,


### PR DESCRIPTION
ghc-events 0.12.0 supports binary event logging. There's no support for it in threadscope yet but it should be safe to upgrade ghc-events anyway.