### PR TITLE
Update ghc-events to 0.13.0

### DIFF
--- a/Events/HECs.hs
+++ b/Events/HECs.hs
@@ -16,6 +16,7 @@ import Events.SparkTree
 import GHC.RTS.Events
 
 import Data.Array
+import Data.Text (Text)
 import qualified Data.List as L
 
 #if MIN_VERSION_containers(0,5,0)
@@ -37,7 +38,7 @@ data HECs = HECs {
        maxXHistogram    :: Int,
        maxYHistogram    :: Timestamp,
        durHistogram     :: [(Timestamp, Int, Timestamp)],
-       perfNames        :: IM.IntMap String
+       perfNames        :: IM.IntMap Text
      }
 
 -----------------------------------------------------------------------------
@@ -60,7 +61,7 @@ timestampToEventIndex HECs{hecEventArray=arr} ts =
         mid  = l + (r - l) `quot` 2
         tmid = evTime (arr!mid)
 
-extractUserMarkers :: HECs -> [(Timestamp, String)]
+extractUserMarkers :: HECs -> [(Timestamp, Text)]
 extractUserMarkers hecs =
   [ (ts, mark)
   | (Event ts (UserMarker mark) _) <- elems (hecEventArray hecs) ]

--- a/Events/TestEvents.hs
+++ b/Events/TestEvents.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Events.TestEvents (testTrace)
 where
 

--- a/GUI/BookmarkView.hs
+++ b/GUI/BookmarkView.hs
@@ -15,13 +15,14 @@ import GHC.RTS.Events (Timestamp)
 import Graphics.UI.Gtk
 import qualified Graphics.UI.Gtk.ModelView.TreeView.Compat as Compat
 import Numeric
+import Data.Text (Text)
 
 ---------------------------------------------------------------------------
 
 -- | Abstract bookmark view object.
 --
 data BookmarkView = BookmarkView {
-       bookmarkStore :: ListStore (Timestamp, String)
+       bookmarkStore :: ListStore (Timestamp, Text)
      }
 
 -- | The actions to take in response to TraceView events.
@@ -30,12 +31,12 @@ data BookmarkViewActions = BookmarkViewActions {
        bookmarkViewAddBookmark    :: IO (),
        bookmarkViewRemoveBookmark :: Int -> IO (),
        bookmarkViewGotoBookmark   :: Timestamp -> IO (),
-       bookmarkViewEditLabel      :: Int -> String -> IO ()
+       bookmarkViewEditLabel      :: Int -> Text -> IO ()
      }
 
 ---------------------------------------------------------------------------
 
-bookmarkViewAdd :: BookmarkView -> Timestamp -> String -> IO ()
+bookmarkViewAdd :: BookmarkView -> Timestamp -> Text -> IO ()
 bookmarkViewAdd BookmarkView{bookmarkStore} ts label = do
   listStoreAppend bookmarkStore (ts, label)
   return ()
@@ -49,11 +50,11 @@ bookmarkViewClear :: BookmarkView -> IO ()
 bookmarkViewClear BookmarkView{bookmarkStore} =
   listStoreClear bookmarkStore
 
-bookmarkViewGet :: BookmarkView -> IO [(Timestamp, String)]
+bookmarkViewGet :: BookmarkView -> IO [(Timestamp, Text)]
 bookmarkViewGet BookmarkView{bookmarkStore} =
   listStoreToList bookmarkStore
 
-bookmarkViewSetLabel :: BookmarkView -> Int -> String -> IO ()
+bookmarkViewSetLabel :: BookmarkView -> Int -> Text -> IO ()
 bookmarkViewSetLabel BookmarkView{bookmarkStore} n label = do
   (ts,_) <- listStoreGetValue bookmarkStore n
   listStoreSetValue bookmarkStore n (ts, label)

--- a/GUI/EventsView.hs
+++ b/GUI/EventsView.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 module GUI.EventsView (
     EventsView,
     eventsViewNew,
@@ -20,6 +21,9 @@ import Control.Monad.Reader
 import Data.Array
 import Data.IORef
 import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Text.Lazy.Builder.Int as TB (decimal)
 import Numeric
 
 -------------------------------------------------------------------------------
@@ -55,8 +59,8 @@ eventsViewNew builder EventsViewActions{..} = do
   stateRef <- newIORef undefined
 
   let getWidget cast = builderGetObject builder cast
-  drawArea     <- getWidget castToWidget "eventsDrawingArea"
-  vScrollbar   <- getWidget castToVScrollbar "eventsVScroll"
+  drawArea     <- getWidget castToWidget ("eventsDrawingArea" :: T.Text)
+  vScrollbar   <- getWidget castToVScrollbar ("eventsVScroll" :: T.Text)
   adj          <- get vScrollbar rangeAdjustment
 
   -- make the background white
@@ -339,16 +343,14 @@ drawEvents EventsView{drawArea, adj}
   where
     showEventTime (Event time _spec _) =
       showFFloat (Just 6) (fromIntegral time / 1000000) "s"
-    showEventDescr :: Event -> String
-    showEventDescr (Event _time  spec cap) =
-        (case cap of
-          Nothing -> ""
-          Just c  -> "HEC " ++ show c ++ ": ")
-     ++ case spec of
-          UnknownEvent{ref} -> "unknown event; " ++ show ref
-          Message     msg   -> msg
-          UserMessage msg   -> msg
-          _                 -> showEventInfo spec
+    showEventDescr :: Event -> T.Text
+    showEventDescr (Event _time  spec cap) = TL.toStrict $ TB.toLazyText $
+      maybe "" (\c -> "HEC " <> TB.decimal c <> ": ") cap
+        <> case spec of
+          UnknownEvent{ref} -> "unknown event; " <> TB.decimal ref
+          Message     msg   -> TB.fromText msg
+          UserMessage msg   -> TB.fromText msg
+          _                 -> buildEventInfo spec
 
 -------------------------------------------------------------------------------
 

--- a/GUI/EventsView.hs
+++ b/GUI/EventsView.hs
@@ -19,12 +19,14 @@ import qualified GUI.GtkExtras as GtkExt
 
 import Control.Monad.Reader
 import Data.Array
+import Data.Monoid
 import Data.IORef
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import qualified Data.Text.Lazy.Builder.Int as TB (decimal)
 import Numeric
+import Prelude
 
 -------------------------------------------------------------------------------
 

--- a/GUI/Main.hs
+++ b/GUI/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
 module GUI.Main (runGUI) where
 
 -- Imports for GTK
@@ -16,6 +17,7 @@ import qualified Control.Concurrent.Chan as Chan
 import Control.Exception
 import Data.Array
 import Data.Maybe
+import Data.Text (Text)
 
 -- Imports for ThreadScope
 import qualified GUI.App as App
@@ -108,7 +110,7 @@ data Event
 
    | EventBookmarkAdd
    | EventBookmarkRemove Int
-   | EventBookmarkEdit   Int String
+   | EventBookmarkEdit   Int Text
 
    | EventUserError String SomeException
                     -- can add more specific ones if necessary

--- a/GUI/Timeline/HEC.hs
+++ b/GUI/Timeline/HEC.hs
@@ -20,11 +20,13 @@ import qualified GHC.RTS.Events as GHC
 import Control.Monad
 import qualified Data.IntMap as IM
 import Data.Maybe
+import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import qualified Data.Text.Lazy.Builder.Int as TB (decimal)
+import Prelude
 
 renderHEC :: ViewParameters -> Timestamp -> Timestamp
           -> IM.IntMap Text -> (DurationTree,EventTree)

--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -56,7 +56,7 @@ Executable threadscope
                      array < 0.6,
                      mtl < 2.3,
                      filepath < 1.5,
-                     ghc-events >= 0.5 && < 0.13,
+                     ghc-events >= 0.13 && < 0.14,
                      containers >= 0.2 && < 0.7,
                      deepseq >= 1.1,
                      text < 1.3,


### PR DESCRIPTION
As of [ghc-events#55](https://packdeps.haskellers.com/reverse/ghc-events) most of the String fields in EventInfo have been replaced with Text. This patch updates threadscope code accordingly. This is incompatible with older ghc-events.