### PR TITLE
Allow ghc-events 0.14 and template-haskell 2.17

### DIFF
--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -56,14 +56,14 @@ Executable threadscope
                      array < 0.6,
                      mtl < 2.3,
                      filepath < 1.5,
-                     ghc-events >= 0.13 && < 0.14,
+                     ghc-events >= 0.13 && < 0.15,
                      containers >= 0.2 && < 0.7,
                      deepseq >= 1.1,
                      text < 1.3,
                      time >= 1.1 && < 1.11,
                      bytestring < 0.11,
                      file-embed < 0.1,
-                     template-haskell < 2.16,
+                     template-haskell < 2.17,
                      temporary >= 1.1 && < 1.4
 
   include-dirs:      include


### PR DESCRIPTION
To fix the build in nixpkgs with ghc 8.10.2, I had to bump the bounds.

Afterwards, threadscope builds fine for me.
