### PR TITLE
fix spelling errors

### DIFF
--- a/Events/ReadEvents.hs
+++ b/Events/ReadEvents.hs
@@ -35,12 +35,12 @@ import Text.Printf
 -- import qualified GHC.RTS.Events as GHCEvents
 --
 -- The GHC.RTS.Events library returns the profile information
--- in a data-streucture which contains a list data structure
+-- in a data-structure which contains a list data structure
 -- representing the events i.e. [GHCEvents.Event]
 -- ThreadScope transforms this list into an alternative representation
 -- which (for each HEC) records event *durations* which are ordered in time.
 -- The durations represent the run-lengths for thread execution and
--- run-lengths for garbage colleciton. This data-structure is called
+-- run-lengths for garbage collection. This data-structure is called
 -- EventDuration.
 -- ThreadScope then transformations this data-structure into another
 -- data-structure which gives a binary-tree view of the event information
@@ -207,7 +207,7 @@ buildEventLog progress from =
       allHisto :: [(Timestamp, Int, Timestamp)]
       allHisto = catMaybes . sparkSummary M.empty . toList $ sparkProfile
 
-      -- Sparks of zero lenght are already well visualized in other graphs:
+      -- Sparks of zero length are already well visualized in other graphs:
       durHistogram = filter (\ (_, logdur, _) -> logdur > 0) allHisto
       -- Precompute some extremums of the maximal interval, needed for scales.
       durs = [(logdur, dur) | (_start, logdur, dur) <- durHistogram]

--- a/Events/SparkStats.hs
+++ b/Events/SparkStats.hs
@@ -24,7 +24,7 @@ initial = SparkStats 0 0 0 0 0 0 0 0 0
 -- | Create spark stats for a duration, given absolute
 -- numbers of sparks in all categories at the start and end of the duration.
 -- The units for spark transitions (first 6 counters) is [spark/duration]:
--- the fact that intervals may have different lenghts is ignored here.
+-- the fact that intervals may have different lengths is ignored here.
 -- The units for the pool stats are just [spark].
 -- The values in the second counter have to be greater or equal
 -- to the values in the first counter, except for the spark pool size.

--- a/Events/TestEvents.hs
+++ b/Events/TestEvents.hs
@@ -119,7 +119,7 @@ testEventTypes
      EventType wakeup "Wakeup thread" (Just 10),
      EventType startGC "Start GC" (Just 0),
      EventType finishGC "Finish GC" (Just 0),
-     EventType reqSeqGC "Request sequetial GC" (Just 0),
+     EventType reqSeqGC "Request sequential GC" (Just 0),
      EventType reqParGC "Reqpargc parallel GC" (Just 0),
      EventType createSparkThread "Create spark thread" (Just 8),
      EventType logMessage "Log message" Nothing,

--- a/GUI/KeyView.hs
+++ b/GUI/KeyView.hs
@@ -106,10 +106,10 @@ keyData =
      "In the spark conversion  graph the coloured area represents the number " ++
      "of sparks that have fizzled.")
   , ("GCed spark",      KEventAndGraph, gcColour,
-     "As an event it indicates a spark has been GC'd, meaning it has been " ++
+     "As an event it indicates a spark has been GC'ed, meaning it has been " ++
      "discovered that the spark's thunk was no longer needed anywhere. " ++
      "In the spark conversion graph the coloured area represents the number " ++
-     "of sparks that were GC'd.")
+     "of sparks that were GC'ed.")
   ]
 
 
@@ -136,7 +136,7 @@ renderKeyIcon KDuration keyColour = do
 renderKeyIcon KEvent keyColour = renderKEvent keyColour
 renderKeyIcon KEventAndGraph keyColour = do
   renderKEvent keyColour
-  -- An icon roughly repreenting a jagedy graph.
+  -- An icon roughly representing a jaggedy graph.
   let x = fromIntegral ox
       y = fromIntegral hecBarHeight
   C.moveTo    (2*x)    (y - 2)

--- a/GUI/KeyView.hs
+++ b/GUI/KeyView.hs
@@ -106,10 +106,10 @@ keyData =
      "In the spark conversion  graph the coloured area represents the number " ++
      "of sparks that have fizzled.")
   , ("GCed spark",      KEventAndGraph, gcColour,
-     "As an event it indicates a spark has been GC'ed, meaning it has been " ++
+     "As an event it indicates a spark has been GCed, meaning it has been " ++
      "discovered that the spark's thunk was no longer needed anywhere. " ++
      "In the spark conversion graph the coloured area represents the number " ++
-     "of sparks that were GC'ed.")
+     "of sparks that were GCed.")
   ]
 
 

--- a/GUI/SummaryView.hs
+++ b/GUI/SummaryView.hs
@@ -124,7 +124,7 @@ summaryViewNew builder = do
       [ cellText := show ovf ]
     addSparksColumn "Dud" $ \(_, SparkCounts _ _ _ dud _ _) ->
       [ cellText := show dud ]
-    addSparksColumn "GC'd" $ \(_, SparkCounts _ _ _ _ gc _) ->
+    addSparksColumn "GC'ed" $ \(_, SparkCounts _ _ _ _ gc _) ->
       [ cellText := show gc ]
     addSparksColumn "Fizzled" $ \(_, SparkCounts _ _ _ _ _ fiz) ->
       [ cellText := show fiz ]
@@ -714,7 +714,7 @@ accumEvent !statsAccum ev =
       -- For events that contain discrete increments. We assume the event
       -- is emitted close to the end of the process it measures,
       -- so we ignore the first found event, because most of the process
-      -- could have happened before the start of the current inverval.
+      -- could have happened before the start of the current interval.
       -- This is consistent with @alterCounter@. For interval beginning
       -- at time 0, we start with @Just 0@.
       alterIncrement _ Nothing = Just 0
@@ -881,7 +881,7 @@ accumEvent !statsAccum ev =
                         }
                   -- Cap is not in the GC. Mark it as idle to complete
                   -- the identification of caps that take part
-                  -- in the current GC. Without overwritin the mode,
+                  -- in the current GC. Without overwriting the mode,
                   -- the cap could be processed later on as if
                   -- it took part in the GC, giving wrong results.
                   ModeEnd  -> dGC { gcMode = ModeIdle }
@@ -934,7 +934,7 @@ accumEvent !statsAccum ev =
                  ModeIdle  -> errorAs "scanEvents: EndGC ModeIdle"
                               $ sd { dGCTable = IM.insert cap endedGC dGCTable }
           SparkCounters crt dud ovf cnv fiz gcd _rem ->
-            -- We are guranteed the first spark counters event has all zeroes,
+            -- We are guaranteed the first spark counters event has all zeroes,
             -- do we don't need to rig the counters for maximal interval.
             let current = RtsSpark crt dud ovf cnv fiz gcd
             in sd { dsparkTable =

--- a/GUI/SummaryView.hs
+++ b/GUI/SummaryView.hs
@@ -124,7 +124,7 @@ summaryViewNew builder = do
       [ cellText := show ovf ]
     addSparksColumn "Dud" $ \(_, SparkCounts _ _ _ dud _ _) ->
       [ cellText := show dud ]
-    addSparksColumn "GC'ed" $ \(_, SparkCounts _ _ _ _ gc _) ->
+    addSparksColumn "GCed" $ \(_, SparkCounts _ _ _ _ gc _) ->
       [ cellText := show gc ]
     addSparksColumn "Fizzled" $ \(_, SparkCounts _ _ _ _ _ fiz) ->
       [ cellText := show fiz ]

--- a/GUI/Timeline/Sparks.hs
+++ b/GUI/Timeline/Sparks.hs
@@ -239,7 +239,7 @@ renderSparkHistogram ViewParameters{..} hecs =
     drawVRulers
     drawHRulers
     -- Move to the bottom and draw the X scale. The Y scale is drawn
-    -- independetly in another drawing area.
+    -- independently in another drawing area.
     translate 0 (fromIntegral histogramHeight)
     drawXScale
     restore


### PR DESCRIPTION
Events/ReadEvents.hs
Events/SparkStats.hs
Events/TestEvents.hs
GUI/KeyView.hs
GUI/SummaryView.hs
GUI/Timeline/Sparks.hs

<hr>

@satnam6502 (these remain unmodified)

typo `riffile`

papers/haskell_symposium_2009/bsort.tex

typo `%\makeatactive`

don't know why `%\makeactive` would be used

papers/haskell_symposium_2009/ghc-parallel-tuning.tex

typo `supercedes`

papers/haskell_symposium_2009/sigplanconf.cls