### PR TITLE
Update threadscope.cabal to fix broken nixpkgs build

### DIFF
--- a/threadscope.cabal
+++ b/threadscope.cabal
@@ -56,7 +56,7 @@ Executable threadscope
                      array < 0.6,
                      mtl < 2.3,
                      filepath < 1.5,
-                     ghc-events >= 0.13 && < 0.19,
+                     ghc-events >= 0.17.0.3 && < 0.19,
                      containers >= 0.2 && < 0.7,
                      deepseq >= 1.1,
                      text < 2.1,


### PR DESCRIPTION
This package is broken in nixpkgs due to ghc-events. This PR bumps the version so that it builds.