### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - "8.10.7"
           - "8.8.4"
         cabal:
-          - "3.10.1.0"
+          - "3.12.1.0"
         os:
           - ubuntu-latest
           - macOS-latest
@@ -109,7 +109,7 @@ jobs:
           - "8.10.7"
           - "8.8.4"
         cabal:
-          - "3.10.1.0"
+          - "3.12.1.0"
         os:
           - windows-latest
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         ghc:
+          - "9.10.1"
           - "9.8.2"
           - "9.6.4"
           - "9.4.8"
@@ -21,6 +22,9 @@ jobs:
         os:
           - ubuntu-latest
         include:
+          - os: macos-latest
+            ghc: "9.10.1"
+            cabal: "3.12.1.0"
           - os: macos-latest
             ghc: "9.8.2"
             cabal: "3.12.1.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           draft: false
           prerelease: false
   build_windows:
+    if: false # This workflow is currently broken due to C library issues. See: https://github.com/haskell/ThreadScope/issues/135
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           - "3.12.1.0"
         os:
           - ubuntu-latest
-          - macOS-latest
+        include:
+          - os: macos-latest
+            ghc: "9.8.2"
+            cabal: "3.12.1.0"
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This makes CI green by disabling all of the CI jobs that are broken. I tried fixing them and was unsuccessful. This leaves us with only the 2 latest versions of GHC for mac and no jobs for windows. 

We also bump our version of cabal-install and add GHC 9.10 to the matrix.