### PR TITLE
ci: update CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,168 +1,147 @@
 name: CI
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+  release:
+
+env:
+  GHC_FOR_RELEASE: "9.10"
+
 jobs:
-  build_posix:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
-    runs-on: ${{ matrix.os }}
+  build:
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }} ${{matrix.container}}
     strategy:
-      matrix:
-        ghc:
-          - "9.12.1"
-          - "9.10.1"
-          - "9.8.4"
-          - "9.6.6"
-          - "9.4.8"
-          - "9.2.8"
-          - "9.0.2"
-          - "8.10.7"
-          - "8.8.4"
-        cabal:
-          - "3.12.1.0"
-        os:
-          - ubuntu-latest
-        include:
-          - os: macos-latest
-            ghc: "9.12.1"
-            cabal: "3.12.1.0"
-          - os: macos-latest
-            ghc: "9.10.1"
-            cabal: "3.12.1.0"
-          - os: macos-latest
-            ghc: "9.8.2"
-            cabal: "3.12.1.0"
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc-version: ['9.12', '9.10', '9.8', '9.6', '9.4', '9.2']
+        container: ['']
+
+        include:
+          # The windows build is currently broken
+          # See #135
+          #- os: windows-latest
+          #   ghc-version: '9.10'
+          - os: macos-latest
+            ghc-version: '9.10'
+          # gtk2hs is broken under apline
+          # See https://github.com/gtk2hs/gtk2hs/issues/262
+          #- os: ubuntu-latest
+          #  ghc-version: '9.10'
+          #  container: alpine:3.21
+
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Haskell
-        id: setup-haskell-cabal
-        uses: haskell-actions/setup@v2
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
-      - name: Cache cabal-store
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Alpine)
+        if: ${{ startsWith(matrix.container, 'alpine') }}
+        shell: sh
+        run: |
+          apk add bash curl sudo jq pkgconfig \
+          zlib-dev zlib-static binutils curl \
+          gcc g++ gmp-dev libc-dev libffi-dev make \
+          musl-dev ncurses-dev perl tar xz \
+          gtk+2.0-dev
+
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux' && !startsWith(matrix.container, 'alpine')
         run: sudo apt-get update && sudo apt-get install libgtk2.0-dev
+
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install cairo gtk+ pkg-config
+
       - name: Set extra cabal build options (macOS)
         if: runner.os == 'macOS'
-        run: echo "CABAL_BUILD_OPTIONS=--constraint='gtk +have-quartz-gtk'" >> $GITHUB_ENV
-      - name: Build Haskell dependencies
         run: |
-          echo $CABAL_BUILD_OPTIONS
-          eval cabal build $CABAL_BUILD_OPTIONS --enable-tests --enable-benchmarks --dep -j all
-          eval cabal build $CABAL_BUILD_OPTIONS --disable-tests --disable-benchmarks --dep -j all
-      - name: Build ThreadScope
-        run: |
-          DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
-          # Packaging...
-          cabal v2-sdist all
-          # Unpacking...
-          mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
-          cd ${DISTDIR} || false
-          find . -maxdepth 1 -type f -name '*.tar.gz' -exec tar -xvf '{}' \;
-          find . -maxdepth 1 -type f -name '*.tar.gz' -exec rm       '{}' \;
-          PKGDIR_threadscope="$(find . -maxdepth 1 -type d -regex '.*/threadscope-[0-9.]*')"
-          # Generate cabal.project
-          rm -rf cabal.project cabal.project.local cabal.project.freeze
-          touch cabal.project
-          echo "packages: ${PKGDIR_threadscope}" >> cabal.project
-          for pkg in $(ghc-pkg list --simple-output); do
-            echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(threadscope)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local;
-          done
-          cat cabal.project || true
-          cat cabal.project.local || true
-          # Building...
-          # this builds all libraries and executables (without tests/benchmarks)
-          eval cabal build $CABAL_BUILD_OPTIONS --disable-tests --disable-benchmarks all
-          # Building with tests and benchmarks...
-          # build & run tests, build benchmarks
-          eval cabal build $CABAL_BUILD_OPTIONS --enable-tests --enable-benchmarks all
-          # cabal check...
-          (cd ${PKGDIR_threadscope} && cabal -vnormal check)
-          # Building without installed constraints for packages in global-db...
-          rm -f cabal.project.local
-          eval cabal build $CABAL_BUILD_OPTIONS --disable-tests --disable-benchmarks all
-          echo $(cabal v2-exec -v0 which threadscope)
-          cp "$(cabal v2-exec -v0 which threadscope)" "$GITHUB_WORKSPACE/threadscope.$PLATFORM.ghc-$GHCVER"
-          gzip -f "$GITHUB_WORKSPACE/threadscope.$PLATFORM.ghc-$GHCVER"
-        env:
-          GHCVER: ${{ matrix.ghc }}
-          PLATFORM: ${{ matrix.os }}
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.ghc == '9.2.2' }}
-        with:
-          files: threadscope.${{ matrix.os }}.ghc-${{ matrix.ghc }}.gz
-          draft: false
-          prerelease: false
-  build_windows:
-    if: false # This workflow is currently broken due to C library issues. See: https://github.com/haskell/ThreadScope/issues/135
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        ghc:
-          - "9.8.2"
-          - "9.6.4"
-          - "9.4.8"
-          - "9.2.2"
-          - "9.0.2"
-          - "8.10.7"
-          - "8.8.4"
-        cabal:
-          - "3.12.1.0"
-        os:
-          - windows-latest
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Haskell
-        id: setup-haskell-cabal
+          printf 'package gtk\n  flags: +have-quartz-gtk' >>cabal.project
+
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
         uses: haskell-actions/setup@v2
+        id: setup
         with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
-      - name: Install system dependencies
+          ghc-version: ${{ matrix.ghc-version }}
+
+      - name: Enable static build (only on alpine)
+        if: ${{ startsWith(matrix.container, 'alpine') }}
+        run: |
+          echo 'executable-static: true' >>cabal.project
+          echo 'cc-options: -D_Noreturn=' >>cabal.project
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build all --dry-run
+
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        env:
+          key: ${{ runner.os }}${{ matrix.container && '-container-' }}${{matrix.container}}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v4
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Install system dependencies (Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
         uses: msys2/setup-msys2@v2
         with:
           path-type: inherit
           install: >-
             mingw-w64-x86_64-pkg-config
             mingw-w64-x86_64-gtk2
-      - name: Cache cabal-store
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
-      - name: Build Haskell dependencies
-        run: cabal build -j all --dep
-        shell: msys2 {0}
-      - name: Build ThreadScope
+
+      - name: Build
+        run: cabal build all
+
+      - name: Run tests
+        run: cabal test all
+
+      - name: Check cabal file
+        run: cabal check
+
+      - name: Create bindist
+        shell: sh
         run: |
-          cabal build -j all
-          cp -v $(find -name threadscope.exe) ./threadscope.exe
-          7z a threadscope.$PLATFORM.ghc-$GHCVER.zip threadscope.exe
-        shell: msys2 {0}
-        env:
-          PLATFORM: ${{ matrix.os }}
-          GHCVER: ${{ matrix.ghc }}
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.ghc == '9.2.2' }}
+           cabal install --install-method=copy --installdir=dist
+           BINDIST_NAME="threadscope-ghc-${{matrix.ghc-version}}-${{ matrix.os }}${{ matrix.container && '-' }}${{matrix.container && 'alpine'}}"
+           echo "BINDIST_NAME=$BINDIST_NAME" >> "$GITHUB_ENV"
+           tar -czf "$BINDIST_NAME.tar.xz" -C dist threadscope
+           echo bindist is "$BINDIST_NAME.tar.xz"
+
+      - name: Upload bindist to artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.ghc-version == env.GHC_FOR_RELEASE }}
         with:
-          files: threadscope.${{ matrix.os }}.ghc-${{ matrix.ghc }}.zip
-          draft: false
-          prerelease: false
+          name: ${{ env.BINDIST_NAME }}
+          path: ${{ env.BINDIST_NAME}}.tar.xz
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.ghc-version == env.GHC_FOR_RELEASE }}
+        with:
+          files: ${{ env.BINDIST_NAME }}.tar.xz


### PR DESCRIPTION
This reuses the setup from: https://github.com/mpickering/hs-speedscope/pull/24

This upgrades some of the actions we use.

It also adds code to build statically linked bindists with Alpine, but it's currently disabled because gtk2hs can't build under Alpine :(