### PR TITLE
Use styling inside the EventsView

### DIFF
--- a/GUI/ViewerColours.hs
+++ b/GUI/ViewerColours.hs
@@ -137,3 +137,11 @@ setSourceRGBAhex (Color r g b) t
                   (fromIntegral b/0xFFFF) t
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+setSourceRGBAForStyle :: (Style -> StateType -> IO Color) -> Style -> StateType -> Render ()
+setSourceRGBAForStyle getColor style state = do
+  color <- liftIO $ getColor style state
+  setSourceRGBAhex color 1
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes: #139

I took the liberty of removing unused imports while I was at it.

Screenshots of how it looks like for different themes:

<img width="1002" height="159" alt="1" src="https://github.com/user-attachments/assets/6705dba6-79d4-464a-b3b6-0f7c594f4c45" />
<img width="1004" height="163" alt="2" src="https://github.com/user-attachments/assets/da14d512-73d6-4b20-9b60-36927d040224" />
<img width="1007" height="167" alt="3" src="https://github.com/user-attachments/assets/570f53c0-cdef-4f09-a965-39fdd166a244" />
